### PR TITLE
x264: add psfile for adaptive soft pulldown.

### DIFF
--- a/encoder/encoder.c
+++ b/encoder/encoder.c
@@ -1908,6 +1908,7 @@ static int encoder_try_reconfig( x264_t *h, x264_param_t *param, int *rc_reconfi
     COPY( i_slice_count );
     COPY( i_slice_count_max );
     COPY( b_tff );
+    COPY( b_fake_interlaced );
 
     /* VBV can't be turned on if it wasn't on to begin with */
     if( h->param.rc.i_vbv_max_bitrate > 0 && h->param.rc.i_vbv_buffer_size > 0 &&


### PR DESCRIPTION
Usage:

`x264 [...] --psfile filename --fps N/D [...]`

- fps must be specified, and defines the framerate of the container (e.g 30000/1001 for Blu-ray 1080i).
- psfile must be generated with vs-picstruct.